### PR TITLE
DinD support and additional packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,16 @@ FROM ubuntu:22.04
 # Arguments for setting up the image
 ARG RUNNER_VERSION="latest"
 
-# Update package repositories and install any necessary packages
-RUN apt-get update && apt-get install -y curl sudo
+# Install Docker and other necessary packages
+RUN install -m 0755 -d /etc/apt/keyrings && \
+    sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc \
+    sudo chmod a+r /etc/apt/keyrings/docker.asc \
+    echo \
+      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+      $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+    sudo apt-get update &&
+    sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin && \
+    sudo apt-get install git ca-certificates curl unzip build-essential sudo
 
 # Create a folder for actions
 RUN mkdir /actions-runner
@@ -20,7 +28,7 @@ RUN chmod +x /install.sh && /install.sh
 RUN rm -f /install.sh
 
 # Set up and runner account for configuration
-RUN useradd -ms /bin/bash runner && usermod -aG sudo runner
+RUN useradd -ms /bin/bash runner && usermod -aG sudo runner && usermod -aG docker runner
 RUN echo 'runner ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 RUN chown -R runner:runner /actions-runner
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG RUNNER_VERSION="latest"
 # Update system, install necessary packages, 
 RUN apt-get update && \
     apt-get upgrade && \
-    apt-get install git ca-certificates curl unzip sudo && \
+    apt-get install -y git ca-certificates curl unzip sudo && \
     install -m 0755 -d /etc/apt/keyrings && \
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc && \
     chmod a+r /etc/apt/keyrings/docker.asc && \
@@ -16,7 +16,7 @@ RUN apt-get update && \
       "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" \
       | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
     apt-get update && \
-    apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+    apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
 # Create a folder for actions
 RUN mkdir /actions-runner

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,13 @@ RUN apt-get update && \
     apt-get upgrade && \
     apt-get install git ca-certificates curl unzip sudo && \
     install -m 0755 -d /etc/apt/keyrings && \
-    sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc && \
-    sudo chmod a+r /etc/apt/keyrings/docker.asc && \
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc && \
+    chmod a+r /etc/apt/keyrings/docker.asc && \
     echo \
       "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" \
-      | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-    sudo apt-get update && \
-    sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+      | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+    apt-get update && \
+    apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
 # Create a folder for actions
 RUN mkdir /actions-runner

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,16 +5,18 @@ FROM ubuntu:22.04
 # Arguments for setting up the image
 ARG RUNNER_VERSION="latest"
 
-# Install Docker and other necessary packages
-RUN install -m 0755 -d /etc/apt/keyrings && \
-    sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc \
-    sudo chmod a+r /etc/apt/keyrings/docker.asc \
+# Update system, install necessary packages, 
+RUN apt-get update && \
+    apt-get upgrade && \
+    apt-get install git ca-certificates curl unzip sudo && \
+    install -m 0755 -d /etc/apt/keyrings && \
+    sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc && \
+    sudo chmod a+r /etc/apt/keyrings/docker.asc && \
     echo \
-      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
-      $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-    sudo apt-get update &&
-    sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin && \
-    sudo apt-get install git ca-certificates curl unzip build-essential sudo
+      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" \
+      | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+    sudo apt-get update && \
+    sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
 # Create a folder for actions
 RUN mkdir /actions-runner

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,3 +9,5 @@ services:
       RUNNER_USER: ${RUNNER_USER}
       RUNNER_TOKEN: ${RUNNER_TOKEN}
       RUNNER_NAME: ${RUNNER_NAME}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock # Expose Docker socket

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,5 @@ services:
       RUNNER_USER: ${RUNNER_USER}
       RUNNER_TOKEN: ${RUNNER_TOKEN}
       RUNNER_NAME: ${RUNNER_NAME}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock # Expose Docker socket


### PR DESCRIPTION
This pull request updates the Docker setup to enable Docker-in-Docker support for the runner container, allowing workflows to run Docker commands inside the container. The main changes include installing Docker and related tools in the `Dockerfile`, adding the runner user to the Docker group, and exposing the Docker socket in both `docker-compose.yml` files.

**Docker installation and configuration:**

* Added installation steps for Docker and related packages (`docker-ce`, `docker-ce-cli`, `containerd.io`, `docker-buildx-plugin`, `docker-compose-plugin`) in the `Dockerfile`, along with required dependencies.
* Updated user setup in the `Dockerfile` to add the `runner` user to the `docker` group, enabling permission to run Docker commands.

**Docker socket exposure in runner containers:**

* Added a volume mount for `/var/run/docker.sock` in `services:` sections of both `docker-compose.yml` and `docker-compose.dev.yml` to expose the Docker socket to the runner container. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R10-R11) [[2]](diffhunk://#diff-9542f82d64bbeebd91f6236324bfe199e9657e2cb1fd9779d5d6dcdcf9cd4de1R12-R13)